### PR TITLE
fix: parse body may cause JSON parse error while send markdown message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ async function run(): Promise<void> {
     const secretStr = core.getInput('secret')
     const ignoreError = core.getInput('ignoreError') === 'true'
     const secret = secretStr === '' ? undefined : secretStr
-    const data = JSON.parse(body)
     if (secret) {
       core.info('get secret, sign mode')
     }
@@ -22,7 +21,7 @@ async function run(): Promise<void> {
     })
 
     try {
-      const resp = await dingBot.rawSend(data)
+      const resp = await dingBot.rawSend(body)
 
       if (resp?.errcode !== 0) {
         if (ignoreError) {


### PR DESCRIPTION
Seems like dingtalk not use a standard json parser to parse markdown message, thus it support a markdown type message which could not be parsed with `JSON.parse`.

Here is a case whose action was broken after v3 released https://github.com/remaxjs/remax/runs/834051717?check_suite_focus=true

ref pr https://github.com/zcong1993/ding-bot/pull/1

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcong1993/actions-ding/4)
<!-- Reviewable:end -->
